### PR TITLE
Suggestion to take with a block of salt (quotes on non-side-effect calls, and potential use of whenReady)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ class AllAtOnceSpec extends FlatSpec with Matchers with BeforeAndAfterAll with G
 
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
-  "all containers" should "be ready at the same time" in {
+  "all containers" should "be ready" in {
     dockerContainers.map(_.image).foreach(println)
-    dockerContainers.forall(_.isReady().futureValue) shouldBe true
+    dockerContainers.forall(_.isReady.futureValue) shouldBe true
   }
 }
 ```

--- a/core/src/main/scala/com/whisk/docker/DockerKit.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerKit.scala
@@ -39,7 +39,7 @@ trait DockerKit {
   }
 
   def initReadyAll(): Future[Seq[(DockerContainer, Boolean)]] =
-    Future.traverse(dockerContainers)(_.init()).flatMap(Future.traverse(_)(c => c.isReady().map(c -> _).recover {
+    Future.traverse(dockerContainers)(_.init()).flatMap(Future.traverse(_)(c => c.isReady.map(c -> _).recover {
       case e =>
         log.error(e.getMessage, e)
         c -> false

--- a/core/src/main/scala/com/whisk/docker/DockerReadyChecker.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerReadyChecker.scala
@@ -77,7 +77,7 @@ object DockerReadyChecker {
 
   case class HttpResponseCode(port: Int, path: String = "/", host: Option[String] = None, code: Int = 200) extends DockerReadyChecker {
     override def apply(container: DockerContainer)(implicit docker: Docker, ec: ExecutionContext): Future[Boolean] = {
-      container.getPorts().map(_(port)).flatMap { p =>
+      container.getPorts.map(_(port)).flatMap { p =>
         val url = new URL("http", host.getOrElse(docker.host), p, path)
         Future {
           val con = url.openConnection().asInstanceOf[HttpURLConnection]

--- a/scalatest/src/test/scala/com/whisk/docker/AllAtOnceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/AllAtOnceSpec.scala
@@ -11,19 +11,18 @@ class AllAtOnceSpec extends FlatSpec with Matchers with BeforeAndAfterAll with G
 
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
-  "all containers" should "be ready at the same time" in {
+  "all containers" should "be ready" in {
     dockerContainers.map(_.image).foreach(println)
+    dockerContainers.forall(_.isReady.futureValue) shouldBe true
 
-    // Merge the separate futures to one, ready when all the components are
-    //
-    // Note: This is slightly different than the preceding code, which would fail immediately,
-    //      if some container's '.isReady' gives false. Here, all the futures are waited for,
-    //      before making the check. Likely doesn't matter in practise. AKa180216
-    //
-    val allFut: Future[Seq[Boolean]] = Future.sequence( dockerContainers.map(_.isReady) )
-
-    whenReady(allFut) { xs =>
+    /*
+    * Note: Above could be forged into a single 'Future[Seq[Boolean]]' but in that case,
+    *       a failing future would not terminate the test immediately, as it probably does
+    *       above. So here, '.futureValue' is probably the right way to go? AKa180216
+    *
+    whenReady( Future.sequence( dockerContainers.map(_.isReady) ) ) { xs =>
       every (xs) shouldBe true
     }
+    */
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/AllAtOnceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/AllAtOnceSpec.scala
@@ -4,6 +4,8 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Second, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, GivenWhenThen, Matchers}
 
+import scala.concurrent.Future
+
 class AllAtOnceSpec extends FlatSpec with Matchers with BeforeAndAfterAll with GivenWhenThen with ScalaFutures
     with DockerElasticsearchService with DockerCassandraService with DockerNeo4jService with DockerMongodbService with PingContainerKit {
 
@@ -11,6 +13,17 @@ class AllAtOnceSpec extends FlatSpec with Matchers with BeforeAndAfterAll with G
 
   "all containers" should "be ready at the same time" in {
     dockerContainers.map(_.image).foreach(println)
-    dockerContainers.forall(_.isReady().futureValue) shouldBe true
+
+    // Merge the separate futures to one, ready when all the components are
+    //
+    // Note: This is slightly different than the preceding code, which would fail immediately,
+    //      if some container's '.isReady' gives false. Here, all the futures are waited for,
+    //      before making the check. Likely doesn't matter in practise. AKa180216
+    //
+    val allFut: Future[Seq[Boolean]] = Future.sequence( dockerContainers.map(_.isReady) )
+
+    whenReady(allFut) { xs =>
+      every (xs) shouldBe true
+    }
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/CassandraServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/CassandraServiceSpec.scala
@@ -11,6 +11,7 @@ class CassandraServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "cassandra node" should "be ready with log line checker" in {
-    cassandraContainer.isReady().futureValue shouldBe true
+
+    whenReady(cassandraContainer.isReady) { _ shouldBe true }
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/DockerServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerServiceSpec.scala
@@ -16,26 +16,33 @@ class DockerServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
   "docker adapter" should "create container" in {
     When("docker tries to get container's id")
 
-    val id = pingContainer.id.futureValue
-    id should not be null
+    whenReady(pingContainer.id) { id =>
+      id should not be null
 
-    Then("id is in list of running containers")
+      Then("id is in list of running containers")
 
-    pingContainer.isRunning.futureValue shouldBe true
+      whenReady(pingContainer.isRunning) { b =>
+        b shouldBe true
 
-    When("docker is trying to stop container")
-    pingContainer.stop().futureValue
+        When("docker is trying to stop container")
+        whenReady(pingContainer.stop()) { _ =>
 
-    Then("There's no such id in the list of running containers")
-    pingContainer.isRunning.futureValue shouldBe false
+          Then("There's no such id in the list of running containers")
+          whenReady(pingContainer.isRunning) { bb =>
+            bb shouldBe false
+          }
+        }
+      }
+    }
   }
 
   "docker container" should "be available from port" in {
     When("we are building a container with bound port")
-    val ports = pongContainer.getPorts.futureValue
+    whenReady(pongContainer.getPorts) { ports =>
 
-    Then("port 80 should be on container")
-    ports.get(80) should be('nonEmpty)
+      Then("port 80 should be on container")
+      ports should contain key 80
+    }
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/DockerServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerServiceSpec.scala
@@ -21,18 +21,18 @@ class DockerServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll wi
 
     Then("id is in list of running containers")
 
-    pingContainer.isRunning().futureValue shouldBe true
+    pingContainer.isRunning.futureValue shouldBe true
 
     When("docker is trying to stop container")
     pingContainer.stop().futureValue
 
     Then("There's no such id in the list of running containers")
-    pingContainer.isRunning().futureValue shouldBe false
+    pingContainer.isRunning.futureValue shouldBe false
   }
 
   "docker container" should "be available from port" in {
     When("we are building a container with bound port")
-    val ports = pongContainer.getPorts().futureValue
+    val ports = pongContainer.getPorts.futureValue
 
     Then("port 80 should be on container")
     ports.get(80) should be('nonEmpty)

--- a/scalatest/src/test/scala/com/whisk/docker/ElasticsearchServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/ElasticsearchServiceSpec.scala
@@ -11,7 +11,7 @@ class ElasticsearchServiceSpec extends FlatSpec with Matchers with BeforeAndAfte
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "elasticsearch container" should "be ready" in {
-    elasticsearchContainer.isReady().futureValue shouldBe true
+    elasticsearchContainer.isReady.futureValue shouldBe true
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/ElasticsearchServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/ElasticsearchServiceSpec.scala
@@ -11,7 +11,7 @@ class ElasticsearchServiceSpec extends FlatSpec with Matchers with BeforeAndAfte
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "elasticsearch container" should "be ready" in {
-    elasticsearchContainer.isReady.futureValue shouldBe true
+    whenReady(elasticsearchContainer.isReady) { _ shouldBe true }
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/KafkaServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/KafkaServiceSpec.scala
@@ -11,7 +11,7 @@ class KafkaServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll wit
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "kafka container" should "be ready" in {
-    kafkaContainer.isReady.futureValue shouldBe true
+    whenReady(kafkaContainer.isReady) { _ shouldBe true }
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/KafkaServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/KafkaServiceSpec.scala
@@ -11,7 +11,7 @@ class KafkaServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll wit
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "kafka container" should "be ready" in {
-    kafkaContainer.isReady().futureValue shouldBe true
+    kafkaContainer.isReady.futureValue shouldBe true
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/MongodbServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/MongodbServiceSpec.scala
@@ -12,6 +12,6 @@ class MongodbServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll w
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "mongodb node" should "be ready with log line checker" in {
-    mongodbContainer.isReady.futureValue shouldBe true
+    whenReady(mongodbContainer.isReady) { _ shouldBe true }
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/MongodbServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/MongodbServiceSpec.scala
@@ -12,6 +12,6 @@ class MongodbServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll w
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "mongodb node" should "be ready with log line checker" in {
-    mongodbContainer.isReady().futureValue shouldBe true
+    mongodbContainer.isReady.futureValue shouldBe true
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/Neo4jServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/Neo4jServiceSpec.scala
@@ -11,7 +11,7 @@ class Neo4jServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll wit
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "neo4j container" should "be ready" in {
-    neo4jContainer.isReady().futureValue shouldBe true
+    neo4jContainer.isReady.futureValue shouldBe true
   }
 
   "neo4j container" should "pass ready checker with logs" in {

--- a/scalatest/src/test/scala/com/whisk/docker/Neo4jServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/Neo4jServiceSpec.scala
@@ -11,13 +11,13 @@ class Neo4jServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll wit
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "neo4j container" should "be ready" in {
-    neo4jContainer.isReady.futureValue shouldBe true
+    whenReady(neo4jContainer.isReady) { _ shouldBe true }
   }
 
   "neo4j container" should "pass ready checker with logs" in {
     val c = DockerReadyChecker.LogLineContains("Starting HTTP on port :7474")
 
-    c(neo4jContainer).futureValue shouldBe true
+    whenReady(c(neo4jContainer)) { _ shouldBe true }
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/PostgresServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/PostgresServiceSpec.scala
@@ -12,6 +12,6 @@ class PostgresServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll 
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "postgres node" should "be ready with log line checker" in {
-    postgresContainer.isReady().futureValue shouldBe true
+    postgresContainer.isReady.futureValue shouldBe true
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/PostgresServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/PostgresServiceSpec.scala
@@ -12,6 +12,6 @@ class PostgresServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll 
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "postgres node" should "be ready with log line checker" in {
-    postgresContainer.isReady.futureValue shouldBe true
+    whenReady(postgresContainer.isReady) { _ shouldBe true }
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/ZookeeperServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/ZookeeperServiceSpec.scala
@@ -11,7 +11,7 @@ class ZookeeperServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "zookeeper container" should "be ready" in {
-    zookeeperContainer.isReady.futureValue shouldBe true
+    whenReady(zookeeperContainer.isReady) { _ shouldBe true }
   }
 
 }

--- a/scalatest/src/test/scala/com/whisk/docker/ZookeeperServiceSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/ZookeeperServiceSpec.scala
@@ -11,7 +11,7 @@ class ZookeeperServiceSpec extends FlatSpec with Matchers with BeforeAndAfterAll
   implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
 
   "zookeeper container" should "be ready" in {
-    zookeeperContainer.isReady().futureValue shouldBe true
+    zookeeperContainer.isReady.futureValue shouldBe true
   }
 
 }

--- a/specs2/src/test/scala/com/whisk/docker/AllAtOnceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/AllAtOnceSpec.scala
@@ -20,6 +20,6 @@ class AllAtOnceSpec(env: Env) extends Specification
                                                       """
   def x1 = {
     dockerContainers.map(_.image).foreach(println)
-    Future.sequence(dockerContainers.map(_.isReady())) must contain(beTrue).forall.await
+    Future.sequence(dockerContainers.map(_.isReady)) must contain(beTrue).forall.await
   }
 }

--- a/specs2/src/test/scala/com/whisk/docker/CassandraServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/CassandraServiceSpec.scala
@@ -14,5 +14,5 @@ class CassandraServiceSpec(env: Env) extends Specification
   The cassandra node should be ready with log line checker $x1
                                                            """
 
-  def x1 = cassandraContainer.isReady() must beTrue.await
+  def x1 = cassandraContainer.isReady must beTrue.await
 }

--- a/specs2/src/test/scala/com/whisk/docker/DockerServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/DockerServiceSpec.scala
@@ -20,9 +20,9 @@ class DockerServiceSpec(env: Env) extends Specification
   def x1 = docker.client.infoCmd().exec().toString.contains("docker") must beTrue
   def x2 = {
     pingContainer.id must not be empty.await
-    pingContainer.isRunning() must beTrue.await
+    pingContainer.isRunning must beTrue.await
     Await.result(pingContainer.stop(), 1.seconds)
-    pingContainer.isRunning() must beFalse.await
+    pingContainer.isRunning must beFalse.await
   }
-  def x3 = pongContainer.getPorts() must be have key(80).await
+  def x3 = pongContainer.getPorts must be have key(80).await
 }

--- a/specs2/src/test/scala/com/whisk/docker/ElasticsearchServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/ElasticsearchServiceSpec.scala
@@ -15,5 +15,5 @@ class ElasticsearchServiceSpec(env: Env) extends Specification
   The elasticsearch container should be ready $x1
                                               """
 
-  def x1 = elasticsearchContainer.isReady() must beTrue.await
+  def x1 = elasticsearchContainer.isReady must beTrue.await
 }

--- a/specs2/src/test/scala/com/whisk/docker/KafkaServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/KafkaServiceSpec.scala
@@ -14,5 +14,5 @@ class KafkaServiceSpec(env: Env) extends Specification
   The Kafka container should be ready $x1
                                       """
 
-  def x1 = kafkaContainer.isReady() must beTrue.await
+  def x1 = kafkaContainer.isReady must beTrue.await
 }

--- a/specs2/src/test/scala/com/whisk/docker/MongodbServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/MongodbServiceSpec.scala
@@ -15,5 +15,5 @@ class MongodbServiceSpec(env: Env) extends Specification
   The mongodb container should be ready $x1
                                         """
 
-  def x1 = mongodbContainer.isReady() must beTrue.await
+  def x1 = mongodbContainer.isReady must beTrue.await
 }

--- a/specs2/src/test/scala/com/whisk/docker/Neo4jServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/Neo4jServiceSpec.scala
@@ -19,7 +19,7 @@ class Neo4jServiceSpec(env: Env) extends Specification
     pass ready checker with logs $x2
                                  """
 
-  def x1 = neo4jContainer.isReady() must beTrue.await
+  def x1 = neo4jContainer.isReady must beTrue.await
 
   def x2 = {
     val c = DockerReadyChecker.LogLineContains("Starting HTTP on port :7474")

--- a/specs2/src/test/scala/com/whisk/docker/PostgresServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/PostgresServiceSpec.scala
@@ -18,5 +18,5 @@ class PostgresServiceSpec(env: Env) extends Specification
   The Postgres node should be ready with log line checker  $x1
                                                            """
 
-  def x1 = postgresContainer.isReady() must beTrue.await
+  def x1 = postgresContainer.isReady must beTrue.await
 }

--- a/specs2/src/test/scala/com/whisk/docker/ZookeeperServiceSpec.scala
+++ b/specs2/src/test/scala/com/whisk/docker/ZookeeperServiceSpec.scala
@@ -14,5 +14,5 @@ class ZookeeperServiceSpec(env: Env) extends Specification
   The Zookeeper container should be ready $x1
                                           """
 
-  def x1 = zookeeperContainer.isReady() must beTrue.await
+  def x1 = zookeeperContainer.isReady must beTrue.await
 }


### PR DESCRIPTION
First a disclaimer: I'm not 100% sure this PR doesn't change the way tests run. I tend to get at least one test failing on my machine, which is not a good thing. but..

In Scala, it is customary to denote functions with side effects with `()`. In the current code there are things like `.isReady()`. This might be intentional, to highlight that a future is returned, instead of a value. I'll leave you to decide. At first, it felt slightly wrong to me.

Also another thing got to this same PR - please forgive! :) I tend to like using `whenReady` in tests, over explicitly waiting for futures to happen. It's no functional change, but feels more async. I've prepared the below code, showing how it would look with `whenReady`. Again, use of `.futureValue` may be intentional of You.

NOTE: I suggest you not to merge this PR as it is, but use it as a discussion (if needed) on this feedback on the code. Thanks!
