### PR TITLE
Upping docker-java Version to 3.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 lazy val commonSettings = Seq(
   organization := "com.whisk",
-  version := "0.8.0",
+  version := "0.8.1",
   scalaVersion := "2.11.7",
   crossScalaVersions := Seq("2.11.7", "2.10.5"),
   scalacOptions ++= Seq("-feature", "-deprecation"),
@@ -45,7 +45,7 @@ lazy val core =
     .settings(
       name := "docker-testkit-core",
       libraryDependencies ++=
-        Seq("com.github.docker-java" % "docker-java" % "3.0.0-RC5",
+        Seq("com.github.docker-java" % "docker-java" % "3.0.0",
           "com.google.code.findbugs" % "jsr305" % "3.0.1"))
 
 lazy val samples =

--- a/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
@@ -25,10 +25,10 @@ class DockerJavaExecutor(override val host: String, client: DockerClient) extend
         .withPortBindings(
           spec.bindPorts.foldLeft(new Ports()) {
             case (ps, (guestPort, Some(hostPort))) =>
-              ps.bind(ExposedPort.tcp(guestPort), Ports.binding(hostPort))
+              ps.bind(ExposedPort.tcp(guestPort), Ports.Binding.bindPort(hostPort))
               ps
             case (ps, (guestPort, None)) =>
-              ps.bind(ExposedPort.tcp(guestPort), new Ports.Binding())
+              ps.bind(ExposedPort.tcp(guestPort), Ports.Binding.empty())
               ps
           }
         )
@@ -57,7 +57,7 @@ class DockerJavaExecutor(override val host: String, client: DockerClient) extend
       val portMap = containerBindings.collect { case (exposedPort, bindings) if Option(bindings).isDefined =>
         val p = ContainerPort(exposedPort.getPort, PortProtocol.withName(exposedPort.getProtocol.toString.toUpperCase))
         val hostBindings: Seq[PortBinding] = bindings.map { b =>
-          PortBinding(b.getHostIp, b.getHostPort)
+          PortBinding(b.getHostIp, b.getHostPortSpec.toInt)
         }
         p -> hostBindings
       }


### PR DESCRIPTION
The version of docker-java that was being used relied on a very old version of jackson - when this was used with Play 2.5.3, there was a version issue and docker-it started throwing classdef issues.

I'm not 100% happy with the .toInt on the port bindings, but for some reason they changed the interface. I think there may be cases where that fails, maybe it should be guarded with some checking around the toInt. 

The scalatest tests pass on my machine (I wasn't able to get the specs2 tests to pass either with or without this change).
