### PR TITLE
add support for volume mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ trait DockerMongodbService extends DockerKitConfig {
   - `SOME_MAPPING_NAME`
     - `internal` required (Int)
     - `external` optional (Int)
+- `volume-maps` optional structure (list of structures)
+  - `container` required (String)
+  - `host`      required (String)
+  - `rw`        optional (Boolean)
 
 # Testkit
 

--- a/config/src/main/scala/com/whisk/docker/config/DockerTypesafeConfig.scala
+++ b/config/src/main/scala/com/whisk/docker/config/DockerTypesafeConfig.scala
@@ -40,11 +40,14 @@ object DockerTypesafeConfig extends DockerKit {
     }
   }
 
+  case class VolumeMapping(host: String, container: String, rw: Boolean = false)
+
   case class DockerConfig (
     `image-name`: String, command: Option[Seq[String]],
     `environmental-variables`: Seq[String] = Seq.empty,
     `port-maps`: Option[Map[String, DockerConfigPortMap]],
-    `ready-checker`: Option[DockerConfigReadyChecker]) {
+    `ready-checker`: Option[DockerConfigReadyChecker],
+    `volume-maps`: Seq[VolumeMapping] = Seq.empty) {
 
     def toDockerContainer() = {
       val bindPorts =
@@ -55,12 +58,15 @@ object DockerTypesafeConfig extends DockerKit {
         `ready-checker`
           .fold[DockerReadyChecker](AlwaysReady) { _.toReadyChecker }
 
+      val volumeMaps = `volume-maps`.map(vb => (vb.container, (vb.host, vb.rw))).toMap
+
       DockerContainer(
         image = `image-name`,
         command = command,
         bindPorts = bindPorts,
         env = `environmental-variables`,
-        readyChecker = readyChecker
+        readyChecker = readyChecker,
+        volumeMaps = volumeMaps
       )
     }
   }

--- a/config/src/test/resources/application.conf
+++ b/config/src/test/resources/application.conf
@@ -35,6 +35,17 @@ docker {
         internal = 9042
       }
     }
+    volume-maps = [
+      {
+        container = "/opt/data"
+        host = "/opt/docker/data"
+      },
+      {
+        container = "/opt/log"
+        host = "/opt/docker/log"
+        rw = true
+      }
+    ]
   }
 
   mongodb {

--- a/config/src/test/scala/com/whisk/docker/config/test/DockerConfigSpec.scala
+++ b/config/src/test/scala/com/whisk/docker/config/test/DockerConfigSpec.scala
@@ -13,6 +13,7 @@ class DockerConfigSpec extends FlatSpec with Matchers with DockerKitConfig {
       DockerContainer("whisk/cassandra:2.1.8")
         .withPorts(9042 -> None)
         .withReadyChecker(DockerReadyChecker.LogLineContains("Starting listening for CQL clients on"))
+        .withVolumes(("/opt/data", ("/opt/docker/data", false)), ("/opt/log", ("/opt/docker/log", true)))
 
     configureDockerContainer("docker.cassandra") shouldBe cassandraExpected
 

--- a/core/src/main/scala/com/whisk/docker/DockerContainer.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainer.scala
@@ -8,7 +8,8 @@ case class DockerContainer(
                             stdinOpen: Boolean = false,
                             links: Map[DockerContainer, String] = Map.empty,
                             env: Seq[String] = Seq.empty,
-                            readyChecker: DockerReadyChecker = DockerReadyChecker.Always) {
+                            readyChecker: DockerReadyChecker = DockerReadyChecker.Always,
+                            volumeMaps: Map[String,(String,Boolean)] = Map.empty) {
 
   def withCommand(cmd: String*) = copy(command = Some(cmd))
 
@@ -19,4 +20,6 @@ case class DockerContainer(
   def withReadyChecker(checker: DockerReadyChecker) = copy(readyChecker = checker)
 
   def withEnv(env: String*) = copy(env = env)
+
+  def withVolumes(volumeMappings: (String, (String, Boolean))*) = copy(volumeMaps = volumeMappings.toMap)
 }

--- a/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.api.exception.NotFoundException
-import com.github.dockerjava.api.model.{ExposedPort, Frame, Ports}
+import com.github.dockerjava.api.model._
 import com.github.dockerjava.core.command.{LogContainerResultCallback, PullImageResultCallback}
 import com.google.common.io.Closeables
 
@@ -15,6 +15,12 @@ import scala.concurrent.duration.FiniteDuration
 class DockerJavaExecutor(override val host: String, client: DockerClient) extends DockerCommandExecutor {
 
   override def createContainer(spec: DockerContainer)(implicit ec: ExecutionContext): Future[String] = {
+    val volumeToBind: Map[Volume, Bind] = spec.volumeMaps.map { kv =>
+      // kv is (container_path, (host_path, rw mode))
+      val volume: Volume = new Volume(kv._1)
+      (volume, new Bind(kv._2._1, volume, AccessMode.fromBoolean(kv._2._2)))
+    }
+
     val baseCmd =
       client.createContainerCmd(spec.image)
         .withPortSpecs(spec.bindPorts.map(kv => kv._2.fold("")(_.toString + ":") + kv._1).toSeq: _*)
@@ -32,6 +38,9 @@ class DockerJavaExecutor(override val host: String, client: DockerClient) extend
               ps
           }
         )
+        .withVolumes(volumeToBind.keys.toSeq: _*)
+        .withBinds(volumeToBind.values.toSeq: _*)
+
     val cmd = spec.command.fold(baseCmd)(c => baseCmd.withCmd(c: _*))
     Future(cmd.exec()).map { resp =>
       if (resp.getId != null && resp.getId != "") {

--- a/core/src/main/scala/com/whisk/docker/DockerKit.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerKit.scala
@@ -21,8 +21,10 @@ trait DockerKit {
   def dockerContainers: List[DockerContainer] = Nil
 
   // we need ExecutionContext in order to run docker.init() / docker.stop() there
-  implicit lazy val dockerExecutionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(dockerContainers.length * 2))
+  implicit lazy val dockerExecutionContext: ExecutionContext = {
+    // using Math.max to prevent unexpected zero length of docker containers
+    ExecutionContext.fromExecutor(Executors.newFixedThreadPool(Math.max(1, dockerContainers.length * 2)))
+  }
   implicit lazy val dockerExecutor = new DockerJavaExecutor(docker.host, docker.client)
 
   lazy val containerManager = new DockerContainerManager(dockerContainers, dockerExecutor)


### PR DESCRIPTION
ref #36 

When using Kafka docker image (https://github.com/wurstmeister/kafka-docker),  I have to mount docker socket in container in order to let Kafka container find its outside port (by means of using docker command within container).

Any comments are appreciated!
