### PR TITLE
SpotifyDockerCommandExecutor: fix NullPointerException when null is returned from repoTags()

### DIFF
--- a/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
+++ b/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
@@ -110,7 +110,7 @@ class SpotifyDockerCommandExecutor(override val host: String, client: DockerClie
   }
 
   override def listImages()(implicit ec: ExecutionContext): Future[Set[String]] = {
-    Future(client.listImages().asScala.flatMap(_.repoTags().asScala).toSet)
+    Future(client.listImages().asScala.flatMap(img => Option(img.repoTags()).map(_.asScala).getOrElse(Seq.empty)).toSet)
   }
 
   override def pullImage(image: String)(implicit ec: ExecutionContext): Future[Unit] = {


### PR DESCRIPTION
When an image is present that is not tagged, `repoTags()` returns `null`, which is now handled properly.
