### PR TITLE
Container linking

### DIFF
--- a/config/src/main/scala/com/whisk/docker/config/DockerTypesafeConfig.scala
+++ b/config/src/main/scala/com/whisk/docker/config/DockerTypesafeConfig.scala
@@ -42,6 +42,7 @@ object DockerTypesafeConfig extends DockerKit {
   }
 
   case class DockerConfig(`image-name`: String,
+                          `container-name`: Option[String],
                           command: Option[Seq[String]],
                           `environmental-variables`: Seq[String] = Seq.empty,
                           `port-maps`: Option[Map[String, DockerConfigPortMap]],
@@ -57,6 +58,7 @@ object DockerTypesafeConfig extends DockerKit {
 
       DockerContainer(
           image = `image-name`,
+          name = `container-name`,
           command = command,
           bindPorts = bindPorts,
           env = `environmental-variables`,

--- a/core/src/main/scala/com/whisk/docker/DockerCommandExecutor.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerCommandExecutor.scala
@@ -20,7 +20,7 @@ object ContainerPort {
 
 case class PortBinding(hostIp: String, hostPort: Int)
 
-case class InspectContainerResult(running: Boolean, ports: Map[ContainerPort, Seq[PortBinding]])
+case class InspectContainerResult(running: Boolean, ports: Map[ContainerPort, Seq[PortBinding]], name: String)
 
 trait DockerCommandExecutor {
 

--- a/core/src/main/scala/com/whisk/docker/DockerContainer.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainer.scala
@@ -2,12 +2,17 @@ package com.whisk.docker
 
 case class VolumeMapping(host: String, container: String, rw: Boolean = false)
 
+case class ContainerLink(container: DockerContainer, alias: String) {
+  require(container.name.nonEmpty, "Container must have a name")
+}
+
 case class DockerContainer(image: String,
+                           name: Option[String] = None,
                            command: Option[Seq[String]] = None,
                            bindPorts: Map[Int, Option[Int]] = Map.empty,
                            tty: Boolean = false,
                            stdinOpen: Boolean = false,
-                           links: Map[DockerContainer, String] = Map.empty,
+                           links: Seq[ContainerLink] = Seq.empty,
                            env: Seq[String] = Seq.empty,
                            readyChecker: DockerReadyChecker = DockerReadyChecker.Always,
                            volumeMappings: Seq[VolumeMapping] = Seq.empty) {
@@ -16,7 +21,7 @@ case class DockerContainer(image: String,
 
   def withPorts(ps: (Int, Option[Int])*) = copy(bindPorts = ps.toMap)
 
-  def withLinks(links: (DockerContainer, String)*) = copy(links = links.toMap)
+  def withLinks(links: ContainerLink*) = copy(links = links.toSeq)
 
   def withReadyChecker(checker: DockerReadyChecker) = copy(readyChecker = checker)
 

--- a/core/src/main/scala/com/whisk/docker/DockerContainerManager.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainerManager.scala
@@ -75,7 +75,6 @@ object DockerContainerManager {
 
   def buildDependencyGraph(containers: Seq[DockerContainer]): ContainerDependencyGraph = {    
     @tailrec def buildDependencyGraph(graph: ContainerDependencyGraph): ContainerDependencyGraph = graph match {
-      case ContainerDependencyGraph(Nil, Some(dependants)) => dependants
       case ContainerDependencyGraph(containers, dependants) =>
         containers.partition(_.links.isEmpty) match {
           case (containersWithoutLinks, Nil) => graph

--- a/core/src/main/scala/com/whisk/docker/DockerContainerManager.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainerManager.scala
@@ -43,8 +43,8 @@ class DockerContainerManager(containers: Seq[DockerContainer], executor: DockerC
       graph: ContainerDependencyGraph, 
       previousInits: Future[Seq[DockerContainerState]] = Future.successful(Seq.empty)
     ): Future[Seq[DockerContainerState]] = {
-      val updatedInits: Future[Seq[DockerContainerState]] = previousInits.flatMap{ prevInits =>
-        Future.traverse(graph.containers.map(dockerStatesMap))(_.init()).map(prevInits ++ _)
+      val updatedInits = previousInits.flatMap{ prev =>
+        Future.traverse(graph.containers.map(dockerStatesMap))(_.init()).map(prev ++ _)
       }
       if (graph.dependants.isEmpty) updatedInits else initGraph(graph.dependants.get, updatedInits)
     }

--- a/core/src/main/scala/com/whisk/docker/DockerContainerState.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainerState.scala
@@ -75,6 +75,12 @@ class DockerContainerState(spec: DockerContainer) {
       ec: ExecutionContext): Future[Option[InspectContainerResult]] =
     id.flatMap(docker.inspectContainer)
 
+  def getName()(implicit docker: DockerCommandExecutor,
+    ec: ExecutionContext): Future[String] = getRunningContainer.flatMap {
+    case Some(InspectContainerResult(_, _, name)) => Future.successful(name)
+    case None => Future.failed(new RuntimeException(s"Container ${spec.image} is not running"))
+  }
+
   private val _ports = SinglePromise[Map[Int, Int]]
 
   def getPorts()(implicit docker: DockerCommandExecutor,

--- a/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
@@ -85,7 +85,7 @@ class DockerJavaExecutor(override val host: String, client: DockerClient)
           }
           p -> hostBindings
       }
-      InspectContainerResult(running = true, ports = portMap)
+      InspectContainerResult(running = true, ports = portMap, name = result.getName())
     })
     RetryUtils.looped(future.flatMap {
       case Some(x) if x.running => Future.successful(Some(x))

--- a/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
+++ b/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
@@ -71,7 +71,7 @@ class SpotifyDockerCommandExecutor(override val host: String, client: DockerClie
                   ContainerPort.parse(cPort) -> binds
               }
               .toMap
-            Future.successful(Some(InspectContainerResult(info.state().running(), ports)))
+            Future.successful(Some(InspectContainerResult(info.state().running(), ports, info.name())))
           case None =>
             Future.failed(new Exception("can't extract ports"))
         }

--- a/scalatest/src/test/scala/com/whisk/docker/DockerContainerLinkingSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerContainerLinkingSpec.scala
@@ -1,0 +1,47 @@
+package com.whisk.docker
+
+import com.whisk.docker.scalatest.DockerTestKit
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time._
+
+class DockerContainerLinkingSpec extends FlatSpec with Matchers with DockerTestKit {
+     
+    val cmdExecutor = implicitly[DockerCommandExecutor]
+    implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))
+
+    val pingName = "ping"
+    val pongName = "pong"
+    val pingAlias = "pang"
+
+    val pingService = new PingService(pingName, None)
+    val pongService = new PingService(pongName, Some(ContainerLink(pingService.container, pingAlias)))
+ 
+  "A DockerContainer" should "be linked to the specified containers upon start" in {
+      pingService.startAllOrFail()
+      pongService.startAllOrFail()
+
+      val ping = cmdExecutor.inspectContainer(pingName)
+      val pongPing = cmdExecutor.inspectContainer(s"$pongName/$pingAlias")
+
+      whenReady(ping) { pingState =>
+        whenReady(pongPing) { pongPingState =>
+          pingState should not be empty
+          pingState shouldBe pongPingState
+        }
+      }
+
+      pingService.stopAllQuietly()
+      pongService.stopAllQuietly()
+  }
+}
+
+class PingService(name: String, link: Option[ContainerLink]) extends DockerKit {
+  private val tmpContainer = DockerContainer("nginx:1.7.11", name = Some(name))
+    .withPorts(80 -> None)
+    .withReadyChecker(DockerReadyChecker.HttpResponseCode(port = 80, path = "/", host = None, code = 200)) 
+
+  val container = link.fold(tmpContainer)(link => tmpContainer.withLinks(link))
+
+  override def dockerContainers  = container :: super.dockerContainers
+}

--- a/scalatest/src/test/scala/com/whisk/docker/DockerContainerLinkingSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerContainerLinkingSpec.scala
@@ -1,11 +1,15 @@
 package com.whisk.docker
 
 import com.whisk.docker.scalatest.DockerTestKit
+import com.whisk.docker.impl.dockerjava._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time._
 
-class DockerContainerLinkingSpec extends FlatSpec with Matchers with DockerTestKit {
+class DockerContainerLinkingSpec extends FlatSpec 
+  with Matchers
+  with DockerTestKit
+  with DockerKitDockerJava {
      
     val cmdExecutor = implicitly[DockerCommandExecutor]
     implicit val pc = PatienceConfig(Span(20, Seconds), Span(1, Second))

--- a/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
@@ -6,35 +6,45 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time._
 import DockerContainerManager._
 
-class DockerContainerManagerSpec extends FlatSpec with Matchers with DockerTestKit {
- 
-  "The DockerContainerManager" should "determine the container startup dependency graph" in {
-    val container1 = DockerContainer("nginx:1.7.11", name = Some("container1"))
-    val container2a = DockerContainer("nginx:1.7.11", name = Some("container2a")).withLinks(ContainerLink(container1, "container1"))
-    val container2b = DockerContainer("nginx:1.7.11", name = Some("container2b")).withLinks(ContainerLink(container1, "container1"))
-    val container3 = DockerContainer("nginx:1.7.11", name = Some("container3")).withLinks(ContainerLink(container2a, "container2a"))
-    val container4 = DockerContainer("nginx:1.7.11", name = Some("container4")).withLinks(ContainerLink(container3, "container4"))//.withLinks(ContainerLink(container2b, "container2b"))
-    val container5 = DockerContainer("nginx:1.7.11", name = Some("container5"))
-    val containers = List(container1, container2a, container2b, container3, container4, container5)
+class DockerContainerManagerSpec extends WordSpecLike with Matchers {
 
-    buildDependencyGraph(containers) shouldBe ContainerDependencyGraph(
-      containers = Seq(container1, container5),
-      dependants = Some(ContainerDependencyGraph(
-        containers = Seq(container2a, container2b),
+  val container1 = DockerContainer("nginx:1.7.11", name = Some("container1"))
+  val container2a = DockerContainer("nginx:1.7.11", name = Some("container2a")).withLinks(ContainerLink(container1, "container1"))
+  val container2b = DockerContainer("nginx:1.7.11", name = Some("container2b")).withLinks(ContainerLink(container1, "container1"))
+  val container3 = DockerContainer("nginx:1.7.11", name = Some("container3")).withLinks(ContainerLink(container2a, "container2a"))
+  val container4 = DockerContainer("nginx:1.7.11", name = Some("container4")).withLinks(ContainerLink(container3, "container4"))
+  val container5 = DockerContainer("nginx:1.7.11", name = Some("container5"))
+  val containers = List(container1, container2a, container2b, container3, container4, container5)
+   
+  "The DockerContainerManager" should {
+    "build a dependency graph from a list of containers" in {
+      buildDependencyGraph(containers) shouldBe ContainerDependencyGraph(
+        containers = Seq(container1, container5),
         dependants = Some(ContainerDependencyGraph(
-          containers = Seq(container3),
+          containers = Seq(container2a, container2b),
           dependants = Some(ContainerDependencyGraph(
-            containers = Seq(container4)
+            containers = Seq(container3),
+            dependants = Some(ContainerDependencyGraph(
+              containers = Seq(container4)
+            ))
           ))
         ))
-      ))
-    )
-  }
+      )
+    }
 
-  "The DockerContainerManager" should "define the correct startup order of an empty ContainerDependencyGraph" in {
-    buildDependencyGraph(Seq.empty) shouldBe ContainerDependencyGraph(
-      containers = Seq.empty,
-      dependants = None
-    )
+    "build the dependency graph from an empty list of containers" in {
+      buildDependencyGraph(Seq.empty) shouldBe ContainerDependencyGraph(
+        containers = Seq.empty,
+        dependants = None
+      )
+    }
+
+    "initialize all containers taking into account their dependencies" in {
+      val dockerKit = new DockerKit {
+        override def dockerContainers = containers ++ super.dockerContainers
+      }
+      dockerKit.startAllOrFail()
+      dockerKit.stopAllQuietly()
+    }
   }
 }

--- a/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
@@ -1,6 +1,7 @@
 package com.whisk.docker
 
 import com.whisk.docker.scalatest.DockerTestKit
+import com.whisk.docker.impl.dockerjava._
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time._
@@ -40,7 +41,7 @@ class DockerContainerManagerSpec extends WordSpecLike with Matchers {
     }
 
     "initialize all containers taking into account their dependencies" in {
-      val dockerKit = new DockerKit {
+      val dockerKit = new DockerKit with DockerKitDockerJava {
         override def dockerContainers = containers ++ super.dockerContainers
       }
       dockerKit.startAllOrFail()

--- a/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
@@ -1,0 +1,40 @@
+package com.whisk.docker
+
+import com.whisk.docker.scalatest.DockerTestKit
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time._
+import DockerContainerManager._
+
+class DockerContainerManagerSpec extends FlatSpec with Matchers with DockerTestKit {
+ 
+  "The DockerContainerManager" should "determine the container startup dependency graph" in {
+    val container1 = DockerContainer("nginx:1.7.11", name = Some("container1"))
+    val container2a = DockerContainer("nginx:1.7.11", name = Some("container2a")).withLinks(ContainerLink(container1, "container1"))
+    val container2b = DockerContainer("nginx:1.7.11", name = Some("container2b")).withLinks(ContainerLink(container1, "container1"))
+    val container3 = DockerContainer("nginx:1.7.11", name = Some("container3")).withLinks(ContainerLink(container2a, "container2a"))
+    val container4 = DockerContainer("nginx:1.7.11", name = Some("container4")).withLinks(ContainerLink(container3, "container4"))//.withLinks(ContainerLink(container2b, "container2b"))
+    val container5 = DockerContainer("nginx:1.7.11", name = Some("container5"))
+    val containers = List(container1, container2a, container2b, container3, container4, container5)
+
+    buildDependencyGraph(containers) shouldBe ContainerDependencyGraph(
+      containers = Seq(container1, container5),
+      dependants = Some(ContainerDependencyGraph(
+        containers = Seq(container2a, container2b),
+        dependants = Some(ContainerDependencyGraph(
+          containers = Seq(container3),
+          dependants = Some(ContainerDependencyGraph(
+            containers = Seq(container4)
+          ))
+        ))
+      ))
+    )
+  }
+
+  "The DockerContainerManager" should "define the correct startup order of an empty ContainerDependencyGraph" in {
+    buildDependencyGraph(Seq.empty) shouldBe ContainerDependencyGraph(
+      containers = Seq.empty,
+      dependants = None
+    )
+  }
+}


### PR DESCRIPTION
I've got a use case where I'd like to use the docker linking functionality. After having browsed through the source code I noticed there already was a `withLinks` method, but without implementation, so here a small contribution.

~~In order to link one container to another, the first one must already have started. Starting them (randomly) in parallel thus won't do. In other words, containers that need a linked container should be started separately in another `DockerKit`.~~
