### PR TITLE
support for bind ip in port mappings

### DIFF
--- a/config/src/main/scala/com/whisk/docker/config/DockerTypesafeConfig.scala
+++ b/config/src/main/scala/com/whisk/docker/config/DockerTypesafeConfig.scala
@@ -1,7 +1,7 @@
 package com.whisk.docker.config
 
 import scala.concurrent.duration._
-import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker, VolumeMapping}
+import com.whisk.docker.{DockerContainer, DockerKit, DockerReadyChecker, DockerPortMapping, VolumeMapping}
 
 object DockerTypesafeConfig extends DockerKit {
   val EmptyPortBindings: Map[Int, Option[Int]] = Map.empty
@@ -49,11 +49,11 @@ object DockerTypesafeConfig extends DockerKit {
                           `volume-maps`: Seq[VolumeMapping] = Seq.empty) {
 
     def toDockerContainer() = {
-      val bindPorts = `port-maps`.fold(EmptyPortBindings) { _.values.map(_.asTuple).toMap }
+      val bindPorts = `port-maps`.fold(EmptyPortBindings) { _.values.map(_.asTuple).toMap } mapValues {
+        maybeHostPort => DockerPortMapping(maybeHostPort)
+      }
 
       val readyChecker = `ready-checker`.fold[DockerReadyChecker](AlwaysReady) { _.toReadyChecker }
-
-      val volumeMaps = `volume-maps`.map(vb => (vb.container, (vb.host, vb.rw))).toMap
 
       DockerContainer(
           image = `image-name`,

--- a/core/src/main/scala/com/whisk/docker/DockerContainer.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainer.scala
@@ -2,9 +2,11 @@ package com.whisk.docker
 
 case class VolumeMapping(host: String, container: String, rw: Boolean = false)
 
+case class DockerPortMapping(hostPort: Option[Int] = None, address: String = "0.0.0.0")
+
 case class DockerContainer(image: String,
                            command: Option[Seq[String]] = None,
-                           bindPorts: Map[Int, Option[Int]] = Map.empty,
+                           bindPorts: Map[Int, DockerPortMapping] = Map.empty,
                            tty: Boolean = false,
                            stdinOpen: Boolean = false,
                            links: Map[DockerContainer, String] = Map.empty,
@@ -14,7 +16,9 @@ case class DockerContainer(image: String,
 
   def withCommand(cmd: String*) = copy(command = Some(cmd))
 
-  def withPorts(ps: (Int, Option[Int])*) = copy(bindPorts = ps.toMap)
+  def withPorts(ps: (Int, Option[Int])*) = copy(bindPorts = ps.toMap.mapValues(hostPort => DockerPortMapping(hostPort)))
+  
+  def withPortMapping(ps: (Int, DockerPortMapping)*) = copy(bindPorts = ps.toMap)
 
   def withLinks(links: (DockerContainer, String)*) = copy(links = links.toMap)
 

--- a/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerJavaExecutor.scala
@@ -24,17 +24,20 @@ class DockerJavaExecutor(override val host: String, client: DockerClient)
 
     val baseCmd = client
       .createContainerCmd(spec.image)
-      .withPortSpecs(spec.bindPorts.map(kv => kv._2.fold("")(_.toString + ":") + kv._1).toSeq: _*)
+      .withPortSpecs(spec.bindPorts.map({
+        case (guestPort, DockerPortMapping(Some(hostPort), address)) => s"$address:$hostPort:$guestPort"
+        case (guestPort, DockerPortMapping(None, address)) => s"$address::$guestPort"
+      }).toSeq: _*)
       .withExposedPorts(spec.bindPorts.keys.map(ExposedPort.tcp).toSeq: _*)
       .withTty(spec.tty)
       .withStdinOpen(spec.stdinOpen)
       .withEnv(spec.env: _*)
       .withPortBindings(
           spec.bindPorts.foldLeft(new Ports()) {
-            case (ps, (guestPort, Some(hostPort))) =>
+            case (ps, (guestPort, DockerPortMapping(Some(hostPort), address))) =>
               ps.bind(ExposedPort.tcp(guestPort), Ports.Binding.bindPort(hostPort))
               ps
-            case (ps, (guestPort, None)) =>
+            case (ps, (guestPort, DockerPortMapping(None, address))) =>
               ps.bind(ExposedPort.tcp(guestPort), Ports.Binding.empty())
               ps
           }

--- a/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
+++ b/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
@@ -8,14 +8,14 @@ import java.util.function.Consumer
 
 import com.google.common.io.Closeables
 import com.spotify.docker.client.DockerClient.{AttachParameter, RemoveContainerParam}
-import com.spotify.docker.client.{DockerClient, LogMessage}
 import com.spotify.docker.client.exceptions.ContainerNotFoundException
 import com.spotify.docker.client.messages.{ContainerConfig, HostConfig, PortBinding}
+import com.spotify.docker.client.{DockerClient, LogMessage}
 import com.whisk.docker._
 
-import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class SpotifyDockerCommandExecutor(override val host: String, client: DockerClient)
     extends DockerCommandExecutor {
@@ -23,10 +23,10 @@ class SpotifyDockerCommandExecutor(override val host: String, client: DockerClie
   override def createContainer(spec: DockerContainer)(
       implicit ec: ExecutionContext): Future[String] = {
     val portBindings: Map[String, util.List[PortBinding]] = spec.bindPorts.map {
-      case (port, Some(bindTo)) =>
-        port.toString -> Collections.singletonList(PortBinding.of("0.0.0.0", bindTo))
-      case (port, None) =>
-        port.toString -> Collections.singletonList(PortBinding.randomPort("0.0.0.0"))
+      case (guestPort, DockerPortMapping(Some(hostPort), address)) =>
+        guestPort.toString -> Collections.singletonList(PortBinding.of(address, hostPort))
+      case (guestPort, DockerPortMapping(None, address)) =>
+        guestPort.toString -> Collections.singletonList(PortBinding.randomPort(address))
     }
 
     val hostConfig = HostConfig.builder().portBindings(portBindings.asJava).build()


### PR DESCRIPTION
In some cases it's convenient to specify the address of the published ports (for example, to restrict the published ports to `127.0.0.1`). This PR provides support for that. I kept `DockerContainer.withPorts()` as it is, for compatibility reasons.
