### PR TITLE
Log line receiver

### DIFF
--- a/core/src/main/scala/com/whisk/docker/Docker.scala
+++ b/core/src/main/scala/com/whisk/docker/Docker.scala
@@ -5,7 +5,7 @@ import com.github.dockerjava.core.{DockerClientBuilder, DockerClientConfig}
 import com.github.dockerjava.jaxrs.JerseyDockerCmdExecFactory
 
 class Docker(val config: DockerClientConfig,
-             factory: DockerCmdExecFactory = new JerseyDockerCmdExecFactory) {
+            protected val factory: DockerCmdExecFactory = new JerseyDockerCmdExecFactory) {
   val client = DockerClientBuilder.getInstance(config).withDockerCmdExecFactory(factory).build()
   val host = config.getDockerHost.getHost
 }

--- a/core/src/main/scala/com/whisk/docker/DockerCommandExecutor.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerCommandExecutor.scala
@@ -33,7 +33,13 @@ trait DockerCommandExecutor {
   def inspectContainer(id: String)(
       implicit ec: ExecutionContext): Future[Option[InspectContainerResult]]
 
-  def withLogStreamLines(id: String, withErr: Boolean)(f: String => Boolean)(
+  def withLogStreamLines(id: String, withErr: Boolean)(f: String => Unit)(
+    implicit
+    docker: DockerCommandExecutor,
+    ec: ExecutionContext
+  ): Unit
+
+  def withLogStreamLinesRequirement(id: String, withErr: Boolean)(f: String => Boolean)(
       implicit docker: DockerCommandExecutor,
       ec: ExecutionContext): Future[Unit]
 

--- a/core/src/main/scala/com/whisk/docker/DockerContainer.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainer.scala
@@ -27,5 +27,5 @@ case class DockerContainer(image: String,
 
   def withVolumes(volumeMappings: Seq[VolumeMapping]) = copy(volumeMappings = volumeMappings)
 
-  def withLogLineReceiver(logLineReceiver: Option[LogLineReceiver]) = copy(logLineReceiver = logLineReceiver)
+  def withLogLineReceiver(logLineReceiver: LogLineReceiver) = copy(logLineReceiver = Some(logLineReceiver))
 }

--- a/core/src/main/scala/com/whisk/docker/DockerContainer.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainer.scala
@@ -2,6 +2,8 @@ package com.whisk.docker
 
 case class VolumeMapping(host: String, container: String, rw: Boolean = false)
 
+case class LogLineReceiver(withErr: Boolean, f: String => Unit)
+
 case class DockerContainer(image: String,
                            command: Option[Seq[String]] = None,
                            bindPorts: Map[Int, Option[Int]] = Map.empty,
@@ -10,7 +12,8 @@ case class DockerContainer(image: String,
                            links: Map[DockerContainer, String] = Map.empty,
                            env: Seq[String] = Seq.empty,
                            readyChecker: DockerReadyChecker = DockerReadyChecker.Always,
-                           volumeMappings: Seq[VolumeMapping] = Seq.empty) {
+                           volumeMappings: Seq[VolumeMapping] = Seq.empty,
+                           logLineReceiver: Option[LogLineReceiver] = None) {
 
   def withCommand(cmd: String*) = copy(command = Some(cmd))
 
@@ -23,4 +26,6 @@ case class DockerContainer(image: String,
   def withEnv(env: String*) = copy(env = env)
 
   def withVolumes(volumeMappings: Seq[VolumeMapping]) = copy(volumeMappings = volumeMappings)
+
+  def withLogLineReceiver(logLineReceiver: Option[LogLineReceiver]) = copy(logLineReceiver = logLineReceiver)
 }

--- a/core/src/main/scala/com/whisk/docker/DockerContainerState.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainerState.scala
@@ -47,6 +47,7 @@ class DockerContainerState(spec: DockerContainer) {
       s <- _id.init(docker.createContainer(spec))
       _ <- Future(docker.startContainer(s))
     } yield {
+      spec.logLineReceiver.map { case LogLineReceiver(withErr, f) => docker.withLogStreamLines(s, withErr)(f) }
       runReadyCheck
       this
     }

--- a/core/src/main/scala/com/whisk/docker/DockerReadyChecker.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerReadyChecker.scala
@@ -133,7 +133,7 @@ object DockerReadyChecker {
                                                         ec: ExecutionContext): Future[Boolean] = {
       for {
         id <- container.id
-        _ <- docker.withLogStreamLines(id, withErr = true)(_.contains(str))
+        _ <- docker.withLogStreamLinesRequirement(id, withErr = true)(_.contains(str))
       } yield {
         true
       }

--- a/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
+++ b/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
@@ -86,7 +86,7 @@ class SpotifyDockerCommandExecutor(override val host: String, client: DockerClie
   override def withLogStreamLines(id: String, withErr: Boolean)(f: String => Unit)(
       implicit docker: DockerCommandExecutor,
       ec: ExecutionContext): Unit = {
-    val baseParams = List(AttachParameter.STDOUT, AttachParameter.STREAM)
+    val baseParams = List(AttachParameter.STDOUT, AttachParameter.STREAM, AttachParameter.LOGS)
     val logParams = if (withErr) AttachParameter.STDERR :: baseParams else baseParams
     val streamF = Future(
         client.attachContainer(id,

--- a/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
+++ b/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
@@ -97,7 +97,7 @@ class SpotifyDockerCommandExecutor(override val host: String, client: DockerClie
         stream.forEachRemaining(new Consumer[LogMessage] {
           override def accept(t: LogMessage): Unit = {
             val str = StandardCharsets.US_ASCII.decode(t.content()).toString
-            f(s"$[$id] $str")
+            f(s"[$id] $str")
           }
         })
       }

--- a/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
+++ b/impl/spotify/src/main/scala/com/whisk/docker/impl/spotify/SpotifyDockerCommandExecutor.scala
@@ -97,7 +97,7 @@ class SpotifyDockerCommandExecutor(override val host: String, client: DockerClie
         stream.forEachRemaining(new Consumer[LogMessage] {
           override def accept(t: LogMessage): Unit = {
             val str = StandardCharsets.US_ASCII.decode(t.content()).toString
-            f(str)
+            f(s"$[$id] $str")
           }
         })
       }


### PR DESCRIPTION
This PR provides a way to access the container logs, which might be useful for debugging purposes.
Fix for https://github.com/whisklabs/docker-it-scala/issues/34
