### PR TITLE
Await container stop & remove on shutdown hook

### DIFF
--- a/core/src/main/scala/com/whisk/docker/DockerKit.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerKit.scala
@@ -46,7 +46,7 @@ trait DockerKit {
       val future: Future[Boolean] =
         containerManager.initReadyAll().map(_.map(_._2).forall(identity))
       sys.addShutdownHook(
-          containerManager.stopRmAll()
+          Await.ready(containerManager.stopRmAll(), StopContainersTimeout)
       )
       Await.result(future, StartContainersTimeout)
     } catch {


### PR DESCRIPTION
Fixes orphaned containers if VM has been stopped during tests because of an unhandled exception and possibly leads to crashes during container instantiation when assigning names to containers.