### PR TITLE
Fix random "Container ... is not running" exception.

### DIFF
--- a/core/src/main/scala/com/whisk/docker/DockerContainerState.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainerState.scala
@@ -45,7 +45,7 @@ class DockerContainerState(spec: DockerContainer) {
   def init()(implicit docker: DockerCommandExecutor, ec: ExecutionContext): Future[this.type] = {
     for {
       s <- _id.init(docker.createContainer(spec))
-      _ <- Future(docker.startContainer(s))
+      _ <- docker.startContainer(s)
     } yield {
       spec.logLineReceiver.foreach {
         case LogLineReceiver(withErr, f) => docker.withLogStreamLines(s, withErr)(f)


### PR DESCRIPTION
Sometimes I get "Container ... is not running" from com.spotify.docker.client.DefaultDockerClient.attachContainer.
The reason seems to be that we are not really waiting for container to be started before trying to attach and read log lines from it. In fact, we are waiting for Future[Future[Unit]].