### PR TITLE
Added dependencies without links

### DIFF
--- a/core/src/main/scala/com/whisk/docker/DockerContainer.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainer.scala
@@ -17,6 +17,7 @@ case class DockerContainer(image: String,
                            tty: Boolean = false,
                            stdinOpen: Boolean = false,
                            links: Seq[ContainerLink] = Seq.empty,
+                           unlinkedDependencies: Seq[DockerContainer] = Seq.empty,
                            env: Seq[String] = Seq.empty,
                            networkMode: Option[String] = None,
                            readyChecker: DockerReadyChecker = DockerReadyChecker.Always,
@@ -33,6 +34,11 @@ case class DockerContainer(image: String,
   def withPortMapping(ps: (Int, DockerPortMapping)*) = copy(bindPorts = ps.toMap)
 
   def withLinks(links: ContainerLink*) = copy(links = links.toSeq)
+
+  def withUnlinkedDependencies(unlinkedDependencies: DockerContainer*) =
+    copy(unlinkedDependencies = unlinkedDependencies.toSeq)
+
+  def dependencies: Seq[DockerContainer] = links.map(_.container) ++ unlinkedDependencies
 
   def withReadyChecker(checker: DockerReadyChecker) = copy(readyChecker = checker)
 

--- a/core/src/main/scala/com/whisk/docker/DockerContainerManager.scala
+++ b/core/src/main/scala/com/whisk/docker/DockerContainerManager.scala
@@ -84,11 +84,11 @@ object DockerContainerManager {
     @tailrec def buildDependencyGraph(graph: ContainerDependencyGraph): ContainerDependencyGraph =
       graph match {
         case ContainerDependencyGraph(containers, dependants) =>
-          containers.partition(_.links.isEmpty) match {
+          containers.partition(_.dependencies.isEmpty) match {
             case (containersWithoutLinks, Nil) => graph
             case (containersWithoutLinks, containersWithLinks) =>
               val linkedContainers = containers.foldLeft(Seq[DockerContainer]()) {
-                case (links, container) => (links ++ container.links.map(_.container))
+                case (links, container) => (links ++ container.dependencies)
               }
               val (containersWithLinksAndLinked, containersWithLinksNotLinked) =
                 containersWithLinks.partition(linkedContainers.contains)
@@ -96,7 +96,7 @@ object DockerContainerManager {
                 .map(_.containers)
                 .getOrElse(List.empty)
                 .partition(
-                    _.links.map(_.container).exists(containersWithLinksNotLinked.contains)
+                    _.dependencies.exists(containersWithLinksNotLinked.contains)
                 )
 
               buildDependencyGraph(

--- a/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
+++ b/scalatest/src/test/scala/com/whisk/docker/DockerContainerManagerSpec.scala
@@ -1,51 +1,92 @@
 package com.whisk.docker
 
-import com.whisk.docker.scalatest.DockerTestKit
+import com.whisk.docker.DockerContainerManager._
 import com.whisk.docker.impl.dockerjava._
 import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time._
-import DockerContainerManager._
 
 class DockerContainerManagerSpec extends WordSpecLike with Matchers {
 
-  val container1 = DockerContainer("nginx:1.7.11", name = Some("container1"))
-  val container2a = DockerContainer("nginx:1.7.11", name = Some("container2a")).withLinks(ContainerLink(container1, "container1"))
-  val container2b = DockerContainer("nginx:1.7.11", name = Some("container2b")).withLinks(ContainerLink(container1, "container1"))
-  val container3 = DockerContainer("nginx:1.7.11", name = Some("container3")).withLinks(ContainerLink(container2a, "container2a"))
-  val container4 = DockerContainer("nginx:1.7.11", name = Some("container4")).withLinks(ContainerLink(container3, "container4"))
-  val container5 = DockerContainer("nginx:1.7.11", name = Some("container5"))
-  val containers = List(container1, container2a, container2b, container3, container4, container5)
-   
+
   "The DockerContainerManager" should {
-    "build a dependency graph from a list of containers" in {
-      buildDependencyGraph(containers) shouldBe ContainerDependencyGraph(
-        containers = Seq(container1, container5),
-        dependants = Some(ContainerDependencyGraph(
-          containers = Seq(container2a, container2b),
+    "a list of containers with dependencies" should {
+      val linkedContainer1 = DockerContainer("nginx:1.7.11", name = Some("linkedContainer1"))
+      val linkedContainer2a = DockerContainer("nginx:1.7.11", name = Some("linkedContainer2a")).withLinks(ContainerLink(linkedContainer1, "linkedContainer1"))
+      val linkedContainer2b = DockerContainer("nginx:1.7.11", name = Some("linkedContainer2b")).withLinks(ContainerLink(linkedContainer1, "linkedContainer1"))
+      val linkedContainer3 = DockerContainer("nginx:1.7.11", name = Some("linkedContainer3")).withLinks(ContainerLink(linkedContainer2a, "linkedContainer2a"))
+      val linkedContainer4 = DockerContainer("nginx:1.7.11", name = Some("linkedContainer4")).withLinks(ContainerLink(linkedContainer3, "linkedContainer4"))
+      val linkedContainer5 = DockerContainer("nginx:1.7.11", name = Some("linkedContainer5"))
+      val linkedContainers = List(linkedContainer1, linkedContainer2a, linkedContainer2b, linkedContainer3, linkedContainer4, linkedContainer5)
+
+      "build a dependency graph from a list of containers with dependencies" in {
+        buildDependencyGraph(linkedContainers) shouldBe ContainerDependencyGraph(
+          containers = Seq(linkedContainer1, linkedContainer5),
           dependants = Some(ContainerDependencyGraph(
-            containers = Seq(container3),
+            containers = Seq(linkedContainer2a, linkedContainer2b),
             dependants = Some(ContainerDependencyGraph(
-              containers = Seq(container4)
+              containers = Seq(linkedContainer3),
+              dependants = Some(ContainerDependencyGraph(
+                containers = Seq(linkedContainer4)
+              ))
             ))
           ))
-        ))
-      )
-    }
-
-    "build the dependency graph from an empty list of containers" in {
-      buildDependencyGraph(Seq.empty) shouldBe ContainerDependencyGraph(
-        containers = Seq.empty,
-        dependants = None
-      )
-    }
-
-    "initialize all containers taking into account their dependencies" in {
-      val dockerKit = new DockerKit with DockerKitDockerJava {
-        override def dockerContainers = containers ++ super.dockerContainers
+        )
       }
-      dockerKit.startAllOrFail()
-      dockerKit.stopAllQuietly()
+
+      "build the dependency graph from an empty list of containers" in {
+        buildDependencyGraph(Seq.empty) shouldBe ContainerDependencyGraph(
+          containers = Seq.empty,
+          dependants = None
+        )
+      }
+
+      "initialize all containers taking into account their dependencies" in {
+        val dockerKit = new DockerKit with DockerKitDockerJava {
+          override def dockerContainers = linkedContainers ++ super.dockerContainers
+        }
+        dockerKit.startAllOrFail()
+        dockerKit.stopAllQuietly()
+      }
+    }
+
+    "a list of containers with links" should {
+
+      val unlinkedContainer1 = DockerContainer("nginx:1.7.11", name = Some("unlinkedContainer1"))
+      val unlinkedContainer2a = DockerContainer("nginx:1.7.11", name = Some("unlinkedContainer2a")).withUnlinkedDependencies(unlinkedContainer1)
+      val unlinkedContainer2b = DockerContainer("nginx:1.7.11", name = Some("unlinkedContainer2b")).withUnlinkedDependencies(unlinkedContainer1)
+      val unlinkedContainer3 = DockerContainer("nginx:1.7.11", name = Some("unlinkedContainer3")).withUnlinkedDependencies(unlinkedContainer2a)
+      val unlinkedContainer4 = DockerContainer("nginx:1.7.11", name = Some("unlinkedContainer4")).withUnlinkedDependencies(unlinkedContainer3)
+      val unlinkedContainer5 = DockerContainer("nginx:1.7.11", name = Some("unlinkedContainer5"))
+      val unlinkedContainers = List(unlinkedContainer1, unlinkedContainer2a, unlinkedContainer2b, unlinkedContainer3, unlinkedContainer4, unlinkedContainer5)
+
+      "build a dependency graph from a list of containers" in {
+        buildDependencyGraph(unlinkedContainers) shouldBe ContainerDependencyGraph(
+          containers = Seq(unlinkedContainer1, unlinkedContainer5),
+          dependants = Some(ContainerDependencyGraph(
+            containers = Seq(unlinkedContainer2a, unlinkedContainer2b),
+            dependants = Some(ContainerDependencyGraph(
+              containers = Seq(unlinkedContainer3),
+              dependants = Some(ContainerDependencyGraph(
+                containers = Seq(unlinkedContainer4)
+              ))
+            ))
+          ))
+        )
+      }
+
+      "build the dependency graph from an empty list of containers" in {
+        buildDependencyGraph(Seq.empty) shouldBe ContainerDependencyGraph(
+          containers = Seq.empty,
+          dependants = None
+        )
+      }
+
+      "initialize all containers taking into account their dependencies" in {
+        val dockerKit = new DockerKit with DockerKitDockerJava {
+          override def dockerContainers = unlinkedContainers ++ super.dockerContainers
+        }
+        dockerKit.startAllOrFail()
+        dockerKit.stopAllQuietly()
+      }
     }
   }
 }


### PR DESCRIPTION
Dependency graph was created based on links but links are not allowed with network mode specified.
Made it possible to specify dependant containers.