### PR TITLE
Add LogLineContainsMultiple

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.1
+sbt.version=1.0.2


### PR DESCRIPTION
When dealing with `postgres` Docker images (`9.6-alpine` in my case), it is actually insufficient to do what is in the samples folder (check for the port).
The init script inside the image will start and stop the database and it is possible to determine it "ready" when it is actually in the middle of its initialization (I have this happen to me frequently in CI).
The easiest way to determine that the database is ready for us is to watch for a log line that needs to be printed 4(!) times.
This has proven to be the only sure way:
`.withReadyChecker(LogLineContainsMultiple("ready to accept connections", 4))`

This PR contributes `LogLineContainsMultiple` back to the project, a custom `DockerReadyChecker` that will count how many times a certain String has been matched.

I am also updating SBT to 1.0.2.