### PR TITLE
Update the Elasticsearch Example to Use the Official Repository

### DIFF
--- a/samples/src/main/scala/com/whisk/docker/DockerElasticsearchService.scala
+++ b/samples/src/main/scala/com/whisk/docker/DockerElasticsearchService.scala
@@ -7,14 +7,16 @@ trait DockerElasticsearchService extends DockerKit {
   val DefaultElasticsearchHttpPort = 9200
   val DefaultElasticsearchClientPort = 9300
 
-  val elasticsearchContainer = DockerContainer("elasticsearch:1.7.1")
-    .withPorts(DefaultElasticsearchHttpPort -> None, DefaultElasticsearchClientPort -> None)
+  val elasticsearchContainer: DockerContainer = DockerContainer("docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.4")
+    .withPortMapping(
+      DefaultElasticsearchHttpPort -> DockerPortMapping(Some(DefaultElasticsearchHttpPort)),
+      DefaultElasticsearchClientPort -> DockerPortMapping(Some(DefaultElasticsearchClientPort)))
+    .withEnv("discovery.type=single-node")
     .withReadyChecker(
       DockerReadyChecker
-        .HttpResponseCode(DefaultElasticsearchHttpPort, "/")
+        .HttpResponseCode(DefaultElasticsearchHttpPort, "/", Some("0.0.0.0"))
         .within(100.millis)
-        .looped(20, 1250.millis)
-    )
+        .looped(20, 1250.millis))
 
   abstract override def dockerContainers: List[DockerContainer] =
     elasticsearchContainer :: super.dockerContainers


### PR DESCRIPTION
Official [Elasticsearch Docker images](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).

I also had to change how the IP and ports are assigned so I could access the service in my
tests.