### PR TITLE
Disable X-Pack Security on the Elasticsearch sample.

### DIFF
--- a/samples/src/main/scala/com/whisk/docker/DockerElasticsearchService.scala
+++ b/samples/src/main/scala/com/whisk/docker/DockerElasticsearchService.scala
@@ -3,6 +3,7 @@ package com.whisk.docker
 import scala.concurrent.duration._
 
 trait DockerElasticsearchService extends DockerKit {
+  override val StartContainersTimeout = 60.seconds
 
   val DefaultElasticsearchHttpPort = 9200
   val DefaultElasticsearchClientPort = 9300
@@ -11,7 +12,7 @@ trait DockerElasticsearchService extends DockerKit {
     .withPortMapping(
       DefaultElasticsearchHttpPort -> DockerPortMapping(Some(DefaultElasticsearchHttpPort)),
       DefaultElasticsearchClientPort -> DockerPortMapping(Some(DefaultElasticsearchClientPort)))
-    .withEnv("discovery.type=single-node")
+    .withEnv("discovery.type=single-node", "xpack.security.enabled=false")
     .withReadyChecker(
       DockerReadyChecker
         .HttpResponseCode(DefaultElasticsearchHttpPort, "/", Some("0.0.0.0"))


### PR DESCRIPTION
X-Pack Security requires a password in some versions of elastic.co Docker images.

This is interpreted as a failure of the container to start up by the ready checker.