### PR TITLE
Add DockerClickhouseService to facilitate clickhouse integration in docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ export DOCKER_HOST=unix:///var/run/docker.sock
 - [Mongodb](https://github.com/whisklabs/docker-it-scala/blob/master/samples/src/main/scala/com/whisk/docker/testkit/DockerMongodbService.scala)
 - [MySQL](https://github.com/whisklabs/docker-it-scala/blob/master/samples/src/main/scala/com/whisk/docker/testkit/DockerMysqlService.scala)
 - [Postgres](https://github.com/whisklabs/docker-it-scala/blob/master/samples/src/main/scala/com/whisk/docker/testkit/DockerPostgresService.scala)
+- [Clickhouse](https://github.com/whisklabs/docker-it-scala/blob/master/samples/src/main/scala/com/whisk/docker/testkit/DockerClickhouseService.scala)
 - [Multi container test](https://github.com/whisklabs/docker-it-scala/blob/master/tests/src/test/scala/com/whisk/docker/testkit/test/MultiContainerTest.scala)
-
 # Defining Containers
 
 There are two ways to define a docker container.
@@ -76,7 +76,7 @@ You can check [usage example](https://github.com/whisklabs/docker-it-scala/blob/
 - Mongodb => `docker.mongo`
 - Neo4j => `docker.mysql`
 - Postgres => `docker.postgres`
-
+- Clickhouse => `docker.clickhouse`
 ### Fields
 
 - `image-name` required  (String)

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,8 @@ lazy val tests =
       name := "docker-testkit-tests",
       libraryDependencies ++= Seq(
         "org.postgresql" % "postgresql" % "42.1.4" % "test",
-        "mysql" % "mysql-connector-java" % "5.1.44" % "test"
+        "mysql" % "mysql-connector-java" % "5.1.44" % "test",
+        "com.clickhouse" % "clickhouse-jdbc" % "0.5.0" % "test"
       )
     )
     .dependsOn(core, scalatest, samples % "test")

--- a/core/src/main/scala/com/whisk/docker/testkit/DockerReadyChecker.scala
+++ b/core/src/main/scala/com/whisk/docker/testkit/DockerReadyChecker.scala
@@ -198,6 +198,8 @@ object DockerReadyChecker {
       "mysql"
     } else if (driverLower.contains("postgres")) {
       "postgresql"
+    } else if (driverLower.contains("clickhouse")) {
+      "clickhouse"
     } else {
       throw new IllegalArgumentException("unsupported database for ready check")
     }

--- a/samples/src/main/scala/com/whisk/docker/testkit/DockerClickhouseService.scala
+++ b/samples/src/main/scala/com/whisk/docker/testkit/DockerClickhouseService.scala
@@ -1,0 +1,33 @@
+package com.whisk.docker.testkit
+
+import com.spotify.docker.client.messages.PortBinding
+import com.whisk.docker.testkit.scalatest.DockerTestKitForAll
+import org.scalatest.Suite
+
+import scala.concurrent.duration._
+
+trait DockerClickhouseService extends DockerTestKitForAll { self: Suite =>
+  override val dockerTestTimeouts: DockerTestTimeouts = DockerTestTimeouts(pull = 10.minutes, init = 10.minutes, stop = 1.minutes)
+
+  def ClickhouseAdvertisedPort = 8123
+  def ClickhouseExposedPort = 8123
+
+  val ClickhouseUser = "default"
+  val ClickhousePassword = ""
+
+  val clickhouseContainer = ContainerSpec("clickhouse/clickhouse-server:23.6")
+    .withEnv(s"CLICKHOUSE_USER=$ClickhouseUser", s"CLICKHOUSE_PASSWORD=$ClickhousePassword")
+    .withPortBindings((ClickhouseAdvertisedPort, PortBinding.of("0.0.0.0", ClickhouseExposedPort)))
+    .withReadyChecker(
+      DockerReadyChecker
+       .Jdbc(
+         driverClass = "com.clickhouse.jdbc.ClickHouseDriver",
+        user = ClickhouseUser,
+        password = Some(ClickhousePassword)
+      )
+        .looped(15, 1.second)
+   )
+   .toContainer
+
+  override val managedContainers: ManagedContainers = clickhouseContainer.toManagedContainer
+}

--- a/tests/src/test/scala/com/whisk/docker/testkit/test/ClickhouseServiceTest.scala
+++ b/tests/src/test/scala/com/whisk/docker/testkit/test/ClickhouseServiceTest.scala
@@ -1,0 +1,12 @@
+package com.whisk.docker.testkit.test
+
+import com.whisk.docker.testkit.{ContainerState, DockerClickhouseService}
+import org.scalatest.funsuite.AnyFunSuite
+
+class ClickhouseServiceTest extends AnyFunSuite with DockerClickhouseService {
+  test("test container started") {
+    assert(clickhouseContainer.state().isInstanceOf[ContainerState.Ready], "clickhouse is ready")
+    assert(clickhouseContainer.mappedPortOpt(ClickhouseAdvertisedPort) === Some(ClickhouseExposedPort),
+      "clickhouse port exposed")
+  }
+}


### PR DESCRIPTION
**What type of PR is this**
* new feature

**What this PR does / why we need it**
* [Clickhouse](https://clickhouse.com/) is a fast open-source column-oriented database management system. This PR is to add a new type of service : DockerClickhouseService to facilitate docker based clickhouse integration testing in scala.

**How to test your code**
* run `sbt`
* In sbt run `project tests`
* and then run `testOnly com.whisk.docker.testkit.test.ClickhouseServiceTest`
* Test passed as follows
 > [info] ClickhouseServiceTest:
[info] - test container started
[info] Run completed in 12 seconds, 510 milliseconds.
[info] Total number of tests run: 1
[info] Suites: completed 1, aborted 0
[info] Tests: succeeded 1, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 32 s, completed Dec 22, 2023, 4:51:59 PM